### PR TITLE
unused `get` from 'lodash/fp'

### DIFF
--- a/src/examples/example#4/generic.ts
+++ b/src/examples/example#4/generic.ts
@@ -1,5 +1,3 @@
-import { get } from 'lodash/fp';
-
 // TODO: Let's type our own get function using generics
 const customGet = (obj, key)  => obj[key];
 


### PR DESCRIPTION
get` from 'lodash/fp' was imported, but not used. Was it intentional?